### PR TITLE
Fix obscured mobile purchase charts

### DIFF
--- a/ecommerce_behavior_analysis.html
+++ b/ecommerce_behavior_analysis.html
@@ -199,6 +199,40 @@
             .funnel-insights li {
                 font-size: 0.8rem !important;
             }
+            
+            /* Mobile-specific fixes for pop-up charts */
+            .roi-chart-container,
+            .hour-chart-container {
+                z-index: 999999 !important;
+                position: fixed !important;
+                top: 50% !important;
+                left: 50% !important;
+                transform: translate(-50%, -50%) !important;
+                width: 90vw !important;
+                max-width: 400px !important;
+                min-width: 300px !important;
+                max-height: 80vh !important;
+                overflow-y: auto !important;
+                padding: 1rem !important;
+            }
+            
+            /* Ensure backdrop is visible on mobile */
+            #chartBackdrop {
+                z-index: 999998 !important;
+            }
+            
+            .roi-chart-container #roiChart,
+            .hour-chart-container #hourChart {
+                width: 100% !important;
+                height: auto !important;
+                min-height: 200px !important;
+            }
+            
+            /* Ensure charts are above all other content */
+            .roi-chart-container *,
+            .hour-chart-container * {
+                z-index: inherit !important;
+            }
         }
 
         /* Mobile Responsiveness for Project Overview Section */
@@ -350,8 +384,11 @@
                         <div style="font-size: 0.9rem; color: #666; margin-top: 0.5rem;">
                             Most of the purchase is completed on Sunday.
                         </div>
-                        <div class="roi-chart-container" id="roiChartContainer" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; border-radius: 12px; box-shadow: 0 8px 25px rgba(0,0,0,0.15); padding: 1.5rem; opacity: 0; visibility: hidden; transition: all 0.3s ease; z-index: 99999; min-width: 500px; cursor: pointer;">
-                            <h4 style="text-align: center; color: var(--primary-color); margin-bottom: 1.5rem; font-size: 1.1rem; font-weight: bold;">Daily Conversion Rates</h4>
+                        <div class="roi-chart-container" id="roiChartContainer" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; border-radius: 12px; box-shadow: 0 8px 25px rgba(0,0,0,0.15); padding: 1.5rem; opacity: 0; visibility: hidden; transition: all 0.3s ease; z-index: 999999; min-width: 500px; cursor: pointer;">
+                            <div style="position: relative;">
+                                <button onclick="hideROIChart()" style="position: absolute; top: -10px; right: -10px; background: #ff4444; color: white; border: none; border-radius: 50%; width: 30px; height: 30px; font-size: 18px; cursor: pointer; z-index: 1000000; display: flex; align-items: center; justify-content: center;">×</button>
+                                <h4 style="text-align: center; color: var(--primary-color); margin-bottom: 1.5rem; font-size: 1.1rem; font-weight: bold;">Daily Conversion Rates</h4>
+                            </div>
                             <div id="roiChart" style="width: 450px; height: 250px; margin: 0 auto;">
                                 <!-- Static Bar Chart -->
                                 <div class="static-bar-chart" style="display: flex; flex-direction: column; gap: 8px; height: 100%;">
@@ -428,8 +465,11 @@
                         <div style="font-size: 0.9rem; color: #666; margin-top: 0.5rem;">
                             Peak shopping hours are between 8-10 AM with highest conversion rates, showing a morning peak pattern.
                         </div>
-                        <div class="hour-chart-container" id="hourChartContainer" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; border-radius: 12px; box-shadow: 0 8px 25px rgba(0,0,0,0.15); padding: 1.5rem; opacity: 0; visibility: hidden; transition: all 0.3s ease; z-index: 99999; min-width: 500px; max-height: 600px; overflow-y: auto; cursor: pointer;">
-                            <h4 style="text-align: center; color: var(--primary-color); margin-bottom: 1.5rem; font-size: 1.1rem; font-weight: bold;">Hourly Conversion Rates</h4>
+                        <div class="hour-chart-container" id="hourChartContainer" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; border-radius: 12px; box-shadow: 0 8px 25px rgba(0,0,0,0.15); padding: 1.5rem; opacity: 0; visibility: hidden; transition: all 0.3s ease; z-index: 999999; min-width: 500px; max-height: 600px; overflow-y: auto; cursor: pointer;">
+                            <div style="position: relative;">
+                                <button onclick="hideHourChart()" style="position: absolute; top: -10px; right: -10px; background: #ff4444; color: white; border: none; border-radius: 50%; width: 30px; height: 30px; font-size: 18px; cursor: pointer; z-index: 1000000; display: flex; align-items: center; justify-content: center;">×</button>
+                                <h4 style="text-align: center; color: var(--primary-color); margin-bottom: 1.5rem; font-size: 1.1rem; font-weight: bold;">Hourly Conversion Rates</h4>
+                            </div>
                             <div id="hourChart" style="width: 450px; height: 400px; margin: 0 auto;">
                                 <!-- Static Bar Chart -->
                                 <div class="static-bar-chart" style="display: flex; flex-direction: column; gap: 6px; height: 100%;">
@@ -877,6 +917,9 @@
 
         function showROIChart() {
             const container = document.getElementById('roiChartContainer');
+            const backdrop = addBackdrop();
+            backdrop.style.opacity = '1';
+            backdrop.style.visibility = 'visible';
             container.style.opacity = '1';
             container.style.visibility = 'visible';
             container.style.display = 'block';
@@ -884,6 +927,11 @@
 
         function hideROIChart() {
             const container = document.getElementById('roiChartContainer');
+            const backdrop = document.getElementById('chartBackdrop');
+            if (backdrop) {
+                backdrop.style.opacity = '0';
+                backdrop.style.visibility = 'hidden';
+            }
             container.style.opacity = '0';
             container.style.visibility = 'hidden';
         }
@@ -899,10 +947,40 @@
                 showROIChart();
             }
         }
+        
+        // Add backdrop overlay for better mobile experience
+        function addBackdrop() {
+            let backdrop = document.getElementById('chartBackdrop');
+            if (!backdrop) {
+                backdrop = document.createElement('div');
+                backdrop.id = 'chartBackdrop';
+                backdrop.style.cssText = `
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
+                    background: rgba(0, 0, 0, 0.5);
+                    z-index: 999998;
+                    opacity: 0;
+                    visibility: hidden;
+                    transition: all 0.3s ease;
+                `;
+                backdrop.addEventListener('click', function() {
+                    hideROIChart();
+                    hideHourChart();
+                });
+                document.body.appendChild(backdrop);
+            }
+            return backdrop;
+        }
 
         // Hour Chart Functions
         function showHourChart() {
             const container = document.getElementById('hourChartContainer');
+            const backdrop = addBackdrop();
+            backdrop.style.opacity = '1';
+            backdrop.style.visibility = 'visible';
             container.style.opacity = '1';
             container.style.visibility = 'visible';
             container.style.display = 'block';
@@ -910,6 +988,11 @@
 
         function hideHourChart() {
             const container = document.getElementById('hourChartContainer');
+            const backdrop = document.getElementById('chartBackdrop');
+            if (backdrop) {
+                backdrop.style.opacity = '0';
+                backdrop.style.visibility = 'hidden';
+            }
             container.style.opacity = '0';
             container.style.visibility = 'hidden';
         }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensures 'Purchase by day' and 'Purchase by hour' pop-up charts display correctly on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c832954-a72c-408c-9531-44c0c0731261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c832954-a72c-408c-9531-44c0c0731261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>